### PR TITLE
New run_follow.yml & run_unfollow.yml distinct schedules + README

### DIFF
--- a/.github/workflows/run_follow.yml
+++ b/.github/workflows/run_follow.yml
@@ -1,0 +1,44 @@
+# .github/workflows/run_follow.yml
+name: GitGrowBot Follower (Scheduled hourly)
+# This workflow is used to run the GitGrowBot follow bot on a schedule.
+# It is triggered by a cron schedule and can also be run manually.
+# The workflow is designed to run the follow bot.
+# The follow bot is responsible for following new users from our 5500+ users.
+# The unfollow bot is run in a different workflow (run_unfollow.yml) to keep the workflows separate.
+
+# Runs every hour at minute 5, and you can still trigger it manually
+on:
+  schedule:
+    # Example: every 1 hours at minute 5 
+    - cron: '5 */1 * * *'
+    # Uncomment one of these for a different interval:
+    # - cron: '5 */ * * *'      # every 2 hours at :05
+    # - cron: '5 */3 * * *'    # every 3 hours at :05
+    # - cron: '5 */4 * * *'    # every 4 hours at :05
+  workflow_dispatch: {}  # Allows manual triggering of the workflow
+
+jobs:
+  follow:
+    # Run only for the configured BOT_USER (your username, from GitHub Actions secrets and variables)
+    # This is to prevent the bot from running on forks or other users' repositories.
+    if: github.actor == vars.BOT_USER || github.repository_owner == vars.BOT_USER
+
+    runs-on: ubuntu-latest  # Use the latest Ubuntu runner
+
+    steps:
+      - uses: actions/checkout@v3   # Check out the code
+      - name: Set up Python
+        uses: actions/setup-python@v4  # Set up Python environment
+        with:
+          python-version: '3.10'  # Specify Python version 3.10
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip  # Upgrade pip
+          pip install PyGithub  # Install PyGithub package
+      - name: Run follow bot
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}  # GitHub token from secrets
+          USERNAME_FILE: "config/usernames.txt"  # Path to usernames file
+          WHITELIST_FILE: "config/whitelist.txt"  # Path to whitelist file
+          FOLLOWERS_PER_RUN: "100"  # Number of followers to process per run
+        run: python scripts/gitgrow.py  # Run the follow bot script

--- a/.github/workflows/run_unfollow.yml
+++ b/.github/workflows/run_unfollow.yml
@@ -1,0 +1,34 @@
+# .github/workflows/run_unfollow.yml
+name: GitGrowBot Unfollower (Scheduled weekly)
+# This workflow is used to run the GitGrowBot unfollow bot on a schedule.
+# It is triggered by a cron schedule and can also be run manually.
+# The workflow is designed to run the unfollow bot.
+# The unfollow bot is responsible for unfollowing users who do not follow back.
+# The follow bot is run in a different workflow (run_follow.yml) to keep the workflows separate.
+
+on:
+  schedule:
+    - cron: '5 21 * * 1'   # every Monday at 21:05 UTC → Tuesday 00:05 UTC+3
+  workflow_dispatch: {}
+
+jobs:
+  unfollow:
+    # Run only for the configured BOT_USER (your username, from GitHub Actions secrets and variables)
+    # This is to prevent the bot from running on forks or other users' repositories.
+    if: github.actor == vars.BOT_USER || github.repository_owner == vars.BOT_USER
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3  # Checkout the repository
+      - name: Setup Python
+        uses: actions/setup-python@v4  # Setup Python environment
+        with:
+          python-version: '3.10'  # Specify Python version
+      - name: Install deps
+        run: |
+          pip install --upgrade pip  # Upgrade pip
+          pip install PyGithub  # Install PyGithub package
+      - name: Run unfollowers
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}  # GitHub token for authentication
+          WHITELIST_FILE: config/whitelist.txt  # Path to whitelist file
+        run: python scripts/unfollowers.py  # Run the unfollowers script

--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,3 @@ Thumbs.db
 
 # Drafts and other files
 .github/workflows/run_bot.yml
-.github/workflows/run_unfollow.yml

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ Thumbs.db
 
 # Drafts and other files
 .github/workflows/run_bot.yml
+.github/workflows/run_unfollow.yml

--- a/README.md
+++ b/README.md
@@ -47,10 +47,12 @@ This ensures your follow list stays active while you're busy coding.
 3. In **Settings → Variables → Repository variables**, add **`BOT_USER`** with _your_ GitHub username. *This prevents the workflow from running in other people’s forks unless they set their own name.*
 4. **5,500 + members like you who want to grow are waiting for you in** `config/usernames.txt`.  
 You can join this list too—see below (**⭐ Don't miss out: Join our 5,500+ users**).
-4. Edit the `schedule.cron` in `run_bot.yml` to your desired interval. The default pre-set is an hourly run.
-5. (Important) Edit `config/whitelist.txt` to protect any accounts you never want the script to act on (no unfollowing, no unstarring for usernames in `whitelist.txt`).
-6. (Optional) Copy `.env.example` → `.env` for local testing (or contributors).
-7. **Enable** GitHub Actions in your repo settings.
+5. (Optional) Tweak the schedules in your workflow files:
+    - `.github/workflows/run_follow.yml` runs **hourly at minute 5** by default.
+    - `.github/workflows/run_unfollow.yml` runs **weekly on Tuesdays at 21:05** (UTC) by default.
+6. (Important) Edit `config/whitelist.txt` to protect any accounts you never want the script to act on (no unfollowing, no unstarring for usernames in `whitelist.txt`).
+7. (Optional) Copy `.env.example` → `.env` for local testing (or contributors).
+8. **Enable** GitHub Actions in your repo settings.
 9. Sit back and code—**GitGrowBot** does the networking for you!  
 
 ## Local testing
@@ -94,7 +96,8 @@ Let's grow! 💪
 ├── .gitattributes
 ├── .github
 │   └── workflows
-│       ├── run_bot.yml          # Scheduled: unfollow + follow
+│       ├── run_follow.yml       # Scheduled: follow-only (hourly @ :05)
+│       ├── run_unfollow.yml     # Scheduled: unfollow-only (Tuesdays @ 21:05 UTC)
 │       ├── manual_follow.yml    # workflow_dispatch → follow only
 │       └── manual_unfollow.yml  # workflow_dispatch → unfollow only
 ├── .gitignore


### PR DESCRIPTION
**What’s changed**

* **Extracted two separate scheduled workflows**

  * `run_follow.yml` — runs every hour at minute 5
  * `run_unfollow.yml` — runs once a week on Tuesdays at 00:05 (UTC+3)
* **Kept** `manual_follow.yml` and `manual_unfollow.yml` for on-demand triggering
* **Updated README.md** to:

  * Replace the old single `run_bot.yml` reference with both new workflow files
  * Show default cron schedules for each
  * Clarify directory structure under `.github/workflows`

---

### Why

Splitting follow-and-unfollow into distinct workflows lets you:

* Control each cadence independently
* Avoid running an expensive unfollow pass every hour
* Keep a single “hub” of CI configs, with clear separation of concerns

---

### Files touched

* `.github/workflows/run_follow.yml`
* `.github/workflows/run_unfollow.yml`
* `README.md`

---

### How to test

1. Verify that both workflows appear under **Actions → Workflows**.
2. Check the schedule in each `.yml` matches the README.
3. (Optional) Manually dispatch each via **Run workflow** to ensure they only execute their own script.

---

**Ready to merge:** these changes only touch docs and CI configs—production scripts remain untouched.