### PR TITLE
feat(ci): standardise PAT\_TOKEN usage & introduce stargazer-shoutouts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
 # GitHub Personal Access Token with user:follow scope
-github_token=YOUR_PERSONAL_ACCESS_TOKEN
+PAT_TOKEN=YOUR_PERSONAL_ACCESS_TOKEN

--- a/.github/workflows/manual_follow.yml
+++ b/.github/workflows/manual_follow.yml
@@ -29,5 +29,5 @@ jobs:
 
       - name: Run follow bot
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: python scripts/gitgrow.py

--- a/.github/workflows/manual_unfollow.yml
+++ b/.github/workflows/manual_unfollow.yml
@@ -30,5 +30,5 @@ jobs:
 
       - name: Run unfollow bot
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: python scripts/unfollowers.py

--- a/.github/workflows/run_orgs.yml
+++ b/.github/workflows/run_orgs.yml
@@ -31,6 +31,6 @@ jobs:
 
       - name: Run organization follow/refollow
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
           python scripts/orgs.py

--- a/.github/workflows/run_unfollow.yml
+++ b/.github/workflows/run_unfollow.yml
@@ -30,6 +30,6 @@ jobs:
           pip install PyGithub  # Install PyGithub package
       - name: Run unfollowers
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}  # GitHub token for authentication
+          PAT_TOKEN: ${{ secrets.PAT_TOKEN }}  # GitHub token for authentication
           WHITELIST_FILE: config/whitelist.txt  # Path to whitelist file
         run: python scripts/unfollowers.py  # Run the unfollowers script

--- a/.github/workflows/stargazer_shoutouts.yml
+++ b/.github/workflows/stargazer_shoutouts.yml
@@ -1,0 +1,31 @@
+# .github/workflows/stargazer_shoutouts.yml
+name: GitGrowBot Stargazer Shoutouts (Daily)
+# Automatically welcome new stargazers in Discussions.
+# Runs every day at 06:15 UTC and can also be triggered manually.
+
+on:
+  schedule:
+    - cron: '15 6 * * *'        # daily at 06:15 UTC
+  workflow_dispatch:            # manual trigger
+
+jobs:
+  shout:
+    if: github.repository_owner == vars.BOT_USER
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: pip install PyGithub
+
+      - name: Run shout-out bot
+        env:
+          PAT_TOKEN:           ${{ secrets.PAT_TOKEN }}
+          WELCOME_DISCUSSION_ID:  ${{ secrets.WELCOME_DISCUSSION_ID }}
+        run: python scripts/shoutouts.py

--- a/.github/workflows/stargazer_shoutouts.yml
+++ b/.github/workflows/stargazer_shoutouts.yml
@@ -1,31 +1,53 @@
 # .github/workflows/stargazer_shoutouts.yml
 name: GitGrowBot Stargazer Shoutouts (Daily)
 # Automatically welcome new stargazers in Discussions.
-# Runs every day at 06:15 UTC and can also be triggered manually.
+# Runs daily at 06:15, 12:15 and 18:15 UTC, or manually via the GitHub UI.
 
 on:
   schedule:
-    - cron: '15 6 * * *'        # daily at 06:15 UTC
-  workflow_dispatch:            # manual trigger
+    - cron: '15 6 * * *'    # daily at 06:15 UTC
+    - cron: '15 12 * * *'   # daily at 12:15 UTC
+    - cron: '15 18 * * *'   # daily at 18:15 UTC
+  workflow_dispatch:         # allows manual triggering of the workflow
 
 jobs:
   shout:
-    if: github.repository_owner == vars.BOT_USER
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest   # use the latest Ubuntu runner
+    permissions:
+      contents: write        # grant write permissions to contents
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout feature branch
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.PAT_TOKEN }}  # use the personal access token from secrets
+          ref: feature/discussion-stargazer-shoutouts  # checkout the specific feature branch
+          fetch-depth: 0    # fetch all history for all branches and tags
 
-      - name: Set up Python
+      - name: Set up Python & deps
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
-
-      - name: Install dependencies
-        run: pip install PyGithub
+          python-version: '3.10'  # specify Python version 3.10
+      - run: pip install PyGithub  # install PyGithub package
 
       - name: Run shout-out bot
         env:
-          PAT_TOKEN:           ${{ secrets.PAT_TOKEN }}
-          WELCOME_DISCUSSION_ID:  ${{ secrets.WELCOME_DISCUSSION_ID }}
-        run: python scripts/shoutouts.py
+          PAT_TOKEN:             ${{ secrets.PAT_TOKEN }}  # set PAT_TOKEN environment variable
+          GITHUB_REPOSITORY:     ${{ github.repository }}  # set GITHUB_REPOSITORY environment variable
+          WELCOME_DISCUSSION_ID: ${{ secrets.WELCOME_DISCUSSION_ID }}  # set WELCOME_DISCUSSION_ID environment variable
+        run: python scripts/shoutouts.py  # run the shoutouts.py script
+
+      - name: Persist updated state
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add .github/state/stars.json
+          if git diff --cached --quiet; then
+            echo "No changes to persist."
+          else
+            COUNT=$(git log --grep='^chore: update stargazers state' --oneline | wc -l)
+            NEXT=$((COUNT + 1))
+            git commit -m "chore: update stargazers state (#${NEXT})"
+            git push origin HEAD:feature/discussion-stargazer-shoutouts
+          fi

--- a/scripts/integrity.py
+++ b/scripts/integrity.py
@@ -14,9 +14,9 @@ from github import Github, GithubException
 
 def main():
     load_dotenv()
-    token = os.getenv("GITHUB_TOKEN")
+    token = os.getenv("PAT_TOKEN")
     if not token:
-        sys.exit("Error: GITHUB_TOKEN environment variable is required")
+        sys.exit("Error: PAT_TOKEN environment variable is required")
     gh = Github(token)
 
     base_dir      = Path(__file__).parent.parent

--- a/scripts/orgs.py
+++ b/scripts/orgs.py
@@ -7,9 +7,9 @@ from github import Github, GithubException
 
 def main():
     # — Auth & client setup —
-    token = os.getenv("GITHUB_TOKEN")
+    token = os.getenv("PAT_TOKEN")
     if not token:
-        sys.exit("[FATAL] GITHUB_TOKEN environment variable is required")
+        sys.exit("[FATAL] PAT_TOKEN environment variable is required")
 
     gh = Github(token)
     try:

--- a/scripts/shoutouts.py
+++ b/scripts/shoutouts.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+import os, json
+from pathlib import Path
+from github import Github
+
+WELCOME_DISCUSSION_ID = int(os.environ["WELCOME_DISCUSSION_ID"])
+TOKEN         = os.environ["PAT_TOKEN"]
+STATE_FILE    = Path(".github/state/stars.json")   # simple key-value cache
+
+gh     = Github(TOKEN)
+repo   = gh.get_repo(os.environ["GITHUB_REPOSITORY"])
+thread = repo.get_discussion(WELCOME_DISCUSSION_ID)
+
+# ---------- 1. Load last run state ----------
+STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+if STATE_FILE.exists():
+    cache = json.loads(STATE_FILE.read_text())
+    seen  = set(cache["stars"])
+else:
+    seen  = set()
+
+current = {u.login.lower() for u in repo.get_stargazers()}
+
+# ---------- 2. Diff ----------
+new_stars  = current - seen
+un_stars   = seen    - current
+
+# ---------- 3. Post messages ----------
+def post(msg): thread.create_comment(msg)
+
+if new_stars:
+    msg = (
+        "🎉 **A sky full of new stars!** 🌟 Welcome aboard: "
+        + ", ".join(f"@{u}" for u in sorted(new_stars))
+        + "\n\n"
+        "> _'Cause you're a sky, you're a sky full of stars_\n"
+        "> _I'm gonna give you my heart..._\n\n"
+        "You've been added to `usernames.txt`. Glad to have you here!"
+    )
+    post(msg)
+
+if un_stars:
+    msg = (
+        "👋 **Oh no, stars fading away...** We'll miss you: "
+        + ", ".join(f"@{u}" for u in sorted(un_stars))
+        + "\n\n"
+        "> _I don't care, go on and tear me apart_\n"
+        "> _I don't care if you do_\n"
+        "> _'Cause in a sky, 'cause in a sky full of stars_\n"
+        "> _I think I saw you..._\n\n"
+        "We've removed you from the list, but you're always welcome back!"
+    )
+    post(msg)
+
+# ---------- 4. Save updated state ----------
+STATE_FILE.write_text(json.dumps({ "stars": sorted(current) }))
+print("Shout-out run complete.")

--- a/scripts/unfollowers.py
+++ b/scripts/unfollowers.py
@@ -6,9 +6,9 @@ from github import Github, GithubException
 
 def main():
     # — Auth & client setup —
-    token = os.getenv("GITHUB_TOKEN")  # Retrieve GitHub token from environment variables
+    token = os.getenv("PAT_TOKEN")  # Retrieve GitHub token from environment variables
     if not token:
-        sys.exit("GITHUB_TOKEN environment variable is required")  # Exit if token is not found
+        sys.exit("PAT_TOKEN environment variable is required")  # Exit if token is not found
     gh = Github(token)  # Initialize GitHub client
     me = gh.get_user()  # Get authenticated user
 

--- a/tests/test_gitgrow_behavior.py
+++ b/tests/test_gitgrow_behavior.py
@@ -45,7 +45,7 @@ class DummyGithub:
 @pytest.fixture(autouse=True)
 def fake_github(monkeypatch):
     # fake token + patch Github()
-    monkeypatch.setenv("GITHUB_TOKEN", "fake")
+    monkeypatch.setenv("PAT_TOKEN", "fake")
     me = DummyMe()
     monkeypatch.setattr("github.Github", lambda token: DummyGithub(me))
     return me

--- a/tests/test_unfollowers.py
+++ b/tests/test_unfollowers.py
@@ -35,7 +35,7 @@ class DummyGithub:
 
 @pytest.fixture(autouse=True)
 def fake_github(monkeypatch):
-    monkeypatch.setenv("GITHUB_TOKEN", "fake")
+    monkeypatch.setenv("PAT_TOKEN", "fake")
     me = DummyMe()
     monkeypatch.setattr("github.Github", lambda token: DummyGithub(me))
     return me


### PR DESCRIPTION
### Summary

1. **Token rename**

   * Replaced all occurrences of `GITHUB_TOKEN` with `PAT_TOKEN` in:

     * `.env.example`
     * CI workflows (`manual_follow.yml`, `manual_unfollow.yml`, `run_orgs.yml`, `run_unfollow.yml`)
     * Scripts (`integrity.py`, `orgs.py`, `unfollowers.py`)
     * Test fixtures (`test_gitgrow_behavior.py`, `test_unfollowers.py`)

2. **New stargazer-shoutouts feature**

   * Added `.github/workflows/stargazer_shoutouts.yml` to run at 06:15, 12:15 and 18:15 UTC (or manually) on a dedicated `feature/discussion-stargazer-shoutouts` branch
   * Created `scripts/shoutouts.py` to:

     * Load and diff `stars.json` cache
     * Post enthusiastic welcome and fond farewells in Discussions, drawing on Coldplay’s “A Sky Full of Stars” lyrics
     * Persist updated state back to the branch with auto-incremented `chore: update stargazers state (#N)` commits

3. **State persistence folder**

   * Initialized `.github/state/` to hold `stars.json` between runs

### Changes by file

* **`.env.example`**

  * `github_token` → `PAT_TOKEN`

* **Workflows**

  * **`manual_follow.yml`**, **`manual_unfollow.yml`**, **`run_orgs.yml`**, **`run_unfollow.yml`**

    * Env var renamed: `GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}`
  * **`stargazer_shoutouts.yml`** (new)

    * Checks out `feature/discussion-stargazer-shoutouts`
    * Runs `scripts/shoutouts.py` and commits back updated JSON

* **Scripts & tests**

  * **`scripts/integrity.py`**, **`scripts/orgs.py`**, **`scripts/unfollowers.py`**

    * `os.getenv("GITHUB_TOKEN")` → `os.getenv("PAT_TOKEN")`
  * **`scripts/shoutouts.py`** (new)
  * **`tests/*`**

    * Fixtures updated to inject `PAT_TOKEN` instead of `GITHUB_TOKEN`

### How to test

1. Push branch to remote and open a PR against `main`.
2. Verify CI passes with the updated token references.
3. Manually dispatch the `stargazer_shoutouts` workflow or wait for a scheduled run; confirm that:

   * New state file is created in `.github/state/stars.json`
   * Comments appear in the target Discussion only when stargazers change
   * Commits to `feature/discussion-stargazer-shoutouts` are tagged `chore: update stargazers state (#N)`

*No functional behaviour was altered outside of token handling and the new shoutouts feature.*