### PR TITLE
feat: add user-level stargazer tracking and reciprocity (autostar/autotrack, beta)

### DIFF
--- a/.github/workflows/run_autostar.yml
+++ b/.github/workflows/run_autostar.yml
@@ -1,0 +1,63 @@
+# .github/workflows/autostar.yml
+name: GitGrowBot AutoStar (Scheduled)
+# This workflow is used to run the GitGrowBot autostar bot on a schedule.
+# It is triggered every hour at minute 5, and can also be run manually.
+# The autostar bot processes stargazers and logs reciprocity results.
+# It fetches state from the tracker-data branch and commits results back there.
+# It also uploads the stargazer logs as an artifact.
+
+on:
+  schedule:
+    - cron: '5 */1 * * *'
+  workflow_dispatch: {}  # Allows manual triggering of the workflow
+
+jobs:
+  autostar:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Needed for git-auto-commit-action
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Fetch state from tracker-data branch
+        run: |
+          git fetch origin tracker-data:tracker-data
+          mkdir -p .github/state/
+          git checkout tracker-data -- .github/state/ || true
+          git checkout ${{ github.ref_name }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run autostar.py
+        run: python3 scripts/autostar.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          BOT_USER: ${{ vars.BOT_USER }}
+
+      - name: Move autostar logs to state folder
+        run: |
+          mkdir -p .github/state/
+          cp scripts/logs/stargazers_*.json .github/state/ || true
+
+      - name: Commit and push stargazer logs to tracker-data
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: log stargazer reciprocity results [bot]"
+          branch: tracker-data
+          file_pattern: .github/state/stargazers_*.json
+
+      - name: Upload stargazer logs as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: stargazer-logs
+          path: .github/state/stargazers_*.json

--- a/.github/workflows/run_follow.yml
+++ b/.github/workflows/run_follow.yml
@@ -2,7 +2,7 @@
 name: GitGrowBot Follower (Scheduled)
 # This workflow is used to run the GitGrowBot follow bot on a schedule.
 # It is triggered every hour at minute 5, and can also be run manually.
-# The follow bot processes a random number of new follows (5–55) each run.
+# The follow bot processes a random number of new follows (5–155) each run.
 # The unfollow bot runs separately on its own schedule.
 
 on:
@@ -32,7 +32,7 @@ jobs:
 
       - name: Generate random follow batch size
         run: |
-          BATCH_SIZE=$(shuf -i 5-55 -n1)
+          BATCH_SIZE=$(shuf -i 5-155 -n1)
           echo "FOLLOWERS_PER_RUN=$BATCH_SIZE" >> $GITHUB_ENV
           echo "Generated FOLLOWERS_PER_RUN=$BATCH_SIZE"
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ All actions run on a schedule (or on demand) in GitHub Actions, so you never nee
 - ❔[Features](#features)
 - ⏭️ [Getting started](#getting-started)
 - [Local testing](#local-testing)
-- ⭐ [Join more than 161,000 users!](#join-more-than-161000-users)
+- ⭐ [Join more than 91,000 users!](#join-more-than-91000-users)
 - [Configuration](#configuration)
 - [Repository structure](#repository-structure)
 - [Manual Troubleshooting Runners (optional)](#manual-troubleshooting-runners-optional)
@@ -34,7 +34,7 @@ This ensures your follow list stays active while you're busy coding.
 ## Features
 
 - **Automated Follow / Unfollow**  
-  - Follows 5 to 55 fresh users each run, from `config/usernames.txt` (**now over 161,000 deduplicated, proofchecked usernames**).
+  - Follows 5 to 155 fresh users each run, from `config/usernames.txt` (**now over 91,000 deduplicated, proofchecked usernames**).
   - Only targets users who have been active in the last 3 days for maximum impact.
   - Duplicates and dead accounts are continuously pruned and removed.
   - Unfollows non-reciprocals.  
@@ -68,8 +68,8 @@ This ensures your follow list stays active while you're busy coding.
 1. **Fork** or **clone** this repo.
 2. In **Settings → Secrets → Actions**, add your Github PAT as `PAT_TOKEN` (scope: `user:follow`).
 3. In **Settings → Variables → Repository variables**, add **`BOT_USER`** with _your_ GitHub username. *This prevents the workflow from running in other people’s forks unless they set their own name.*
-4. **161,000+ members like you who want to grow are waiting for you in** `config/usernames.txt`.  
-You can join this list too—see below (**⭐ & Join more than 161,000 users!**).
+4. **91,000+ members like you who want to grow are waiting for you in** `config/usernames.txt`.  
+You can join this list too—see below (**⭐ & Join more than 91,000 users!**).
 5. (Optional) Tweak the schedules in your workflow files:
     - `.github/workflows/run_follow.yml` runs **hourly at minute 5** by default.
     - `.github/workflows/run_unfollow.yml` runs **every 10 hours at minute 5** (UTC) by default.
@@ -93,14 +93,14 @@ python scripts/cleaner.py
 python scripts/gitgrow.py
 ````
 
-## Join more than 161,000 users!
+## Join more than 91,000 users!
 
 Want in? It’s effortless. If you:
 
 1. **Star** this repository, **AND**
 2. **Follow** both **[@ikramagix](https://github.com/ikramagix)** and **[@gr33kurious](https://github.com/gr33kurious)**
 
-then your username will be **automatically** added to the master `usernames.txt` list alongside the **161,000+** active members!
+then your username will be **automatically** added to the master `usernames.txt` list alongside the **91,000+** active members!
 
 Let's grow! 💪
 
@@ -111,7 +111,7 @@ Let's grow! 💪
 | PAT\_TOKEN          | Your PAT with `user:follow` scope, added in your secrets   | (empty) **required**   |
 | USERNAME\_FILE      | File listing target usernames (in the `config/` directory) | `config/usernames.txt` |
 | WHITELIST\_FILE     | File listing usernames never to unfollow (in `config/`)    | `config/whitelist.txt` |
-| FOLLOWERS\_PER\_RUN | Number of new users to follow each run                     | Random value: `5–55 per run`|
+| FOLLOWERS\_PER\_RUN | Number of new users to follow each run                     | Random value: `5–155 per run`|
 
 ## Repository structure
 
@@ -128,7 +128,7 @@ Let's grow! 💪
 ├── .gitignore
 ├── README.md
 ├── config
-│   ├── usernames.txt              # 161,000+ community members (deduped, activity filtered)
+│   ├── usernames.txt              # 91,000+ community members (deduped, activity filtered)
 │   ├── organizations.txt          # (Optional) org members, only relevant if using run_orgs.yml
 │   └── whitelist.txt              # accounts to always skip
 ├── logs                           # CI artifacts (gitignored)

--- a/config/usernames.txt
+++ b/config/usernames.txt
@@ -35,7 +35,6 @@ six519
 mortonfox
 ravindrank
 joelibaceta
-emaraschio
 marialobillo
 emaiax
 orcololo
@@ -729,7 +728,6 @@ SAPH1TE
 LibanMoo
 Nautevol07VII-111
 honeycrop88
-Ayokanmi-Adejola
 Imtiaz513
 zainab0077
 thevampy
@@ -69278,7 +69276,6 @@ aldob-mohamed96
 NatanVieira
 adkif
 memrdk
-develectro
 aryamtos
 yagoid
 AlineSiqueira
@@ -71770,7 +71767,6 @@ girlbot666
 KamilleXavier
 BerasKewd
 yeasin-gazi
-aflacake
 NovaLogics
 IAdejokun
 Yashraghava
@@ -74040,7 +74036,6 @@ salem2400
 saadivar
 ayushag833
 SouparnaChatterjee
-nasrokamora
 IgorVinniciusEX
 https-taku
 alina-korn

--- a/scripts/autostar.py
+++ b/scripts/autostar.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import json
+import random
+from pathlib import Path
+from github import Github
+
+BOT_USER = os.getenv("BOT_USER")
+TOKEN = os.getenv("GITHUB_TOKEN")
+STATE_PATH = Path(".github/state/stargazer_state.json")
+USERNAMES_PATH = Path("config/usernames.txt")
+GROWTH_SAMPLE = 22
+
+def main():
+    if not TOKEN or not BOT_USER:
+        sys.stderr.write("GITHUB_TOKEN and BOT_USER required\n")
+        sys.exit(1)
+    if not STATE_PATH.exists():
+        sys.stderr.write(f"{STATE_PATH} not found; run autotrack.py first.\n")
+        sys.exit(1)
+
+    gh = Github(TOKEN)
+    me = gh.get_user()
+
+    # Load state
+    with open(STATE_PATH) as f:
+        state = json.load(f)
+    current_stargazers = set(state.get("current_stargazers", []))
+    starred_users = state.get("starred_users", {})
+    unstargazers = set(state.get("unstargazers", []))
+
+    # 1. Star new stargazers
+    new_to_star = [u for u in current_stargazers if u not in starred_users]
+    for user in new_to_star:
+        try:
+            u = gh.get_user(user)
+            repos = [r for r in u.get_repos() if not r.fork and not r.private]
+            if not repos:
+                continue
+            repo = random.choice(repos)
+            me.add_to_starred(repo)
+            starred_users[user] = [repo.full_name]
+            print(f"Starred {repo.full_name} for {user}")
+        except Exception as e:
+            print(f"Failed to star for {user}: {e}")
+
+    # 2. Unstar repos of unstargazers
+    for user in list(unstargazers):
+        if user in starred_users:
+            for repo_name in starred_users[user]:
+                try:
+                    repo = gh.get_repo(repo_name)
+                    me.remove_from_starred(repo)
+                    print(f"Unstarred {repo.full_name} (user {user} unstarred you)")
+                except Exception as e:
+                    print(f"Failed to unstar {repo_name}: {e}")
+            del starred_users[user]
+
+    # 3. Growth: star new users from usernames.txt
+    if USERNAMES_PATH.exists():
+        with open(USERNAMES_PATH) as f:
+            all_usernames = [line.strip() for line in f if line.strip()]
+        available = set(all_usernames) - current_stargazers - set(starred_users)
+        sample = random.sample(list(available), min(GROWTH_SAMPLE, len(available)))
+        for user in sample:
+            try:
+                u = gh.get_user(user)
+                repos = [r for r in u.get_repos() if not r.fork and not r.private]
+                if not repos:
+                    continue
+                repo = random.choice(repos)
+                me.add_to_starred(repo)
+                starred_users[user] = [repo.full_name]
+                print(f"Growth: Starred {repo.full_name} for {user}")
+            except Exception as e:
+                print(f"Failed to star for growth {user}: {e}")
+
+    # 4. Save updated state
+    state["starred_users"] = starred_users
+    with open(STATE_PATH, "w") as f:
+        json.dump(state, f, indent=2)
+    print(f"Updated state written to {STATE_PATH}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/autotrack.py
+++ b/scripts/autotrack.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import json
+from pathlib import Path
+from github import Github
+
+BOT_USER = os.getenv("BOT_USER")
+TOKEN = os.getenv("GITHUB_TOKEN")
+STATE_PATH = Path(".github/state/stargazer_state.json")
+
+def main():
+    if not TOKEN or not BOT_USER:
+        sys.stderr.write("GITHUB_TOKEN and BOT_USER required\n")
+        sys.exit(1)
+
+    gh = Github(TOKEN)
+    user = gh.get_user(BOT_USER)
+
+    # Collect all public, non-fork repos owned by BOT_USER
+    repos = [r for r in user.get_repos(type="owner") if not r.fork and not r.private]
+
+    # Gather unique stargazer usernames across all repos
+    stargazer_set = set()
+    for repo in repos:
+        for u in repo.get_stargazers():
+            stargazer_set.add(u.login)
+    current_stargazers = sorted(stargazer_set)
+
+    # Load previous state if exists
+    if STATE_PATH.exists():
+        with open(STATE_PATH, "r") as f:
+            state = json.load(f)
+        previous_stargazers = set(state.get("current_stargazers", []))
+        starred_users = state.get("starred_users", {})
+    else:
+        previous_stargazers = set()
+        starred_users = {}
+
+    # Detect unstargazers: users who have unstarred since last run
+    unstargazers = sorted(list(previous_stargazers - stargazer_set))
+
+    # Save new state
+    new_state = {
+        "current_stargazers": current_stargazers,
+        "starred_users": starred_users,
+        "unstargazers": unstargazers
+    }
+    STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with open(STATE_PATH, "w") as f:
+        json.dump(new_state, f, indent=2)
+    print(f"Saved user-level stargazer state to {STATE_PATH}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR introduces the *reciprocal starring* feature:

* Adds `scripts/autotrack.py` to track unique stargazers across all public, non-fork repos owned by `BOT_USER`
* Adds `scripts/autostar.py` to automate starring back (and unstarring) at the user level, plus optional growth outreach
* State is stored in `.github/state/stargazer_state.json` (single minimal JSON, user-level only)
* New workflow `.github/workflows/run_autostar.yml` to automate and persist to `tracker-data` branch
* Handles deduplication, unstar logic, and configurable sampling for outreach

> [!NOTE]
> Designed to enable full star-for-star automation at the account level (not per-repo)
> No per-repo state is stored; all actions are at the unique stargazer user level